### PR TITLE
Docs (#4)

### DIFF
--- a/doc/minisnip.txt
+++ b/doc/minisnip.txt
@@ -13,6 +13,7 @@ License: MIT
 1. Overview                    |minisnip-overview|
 2. Mappings                    |minisnip-mappings|
 3. Configuration               |minisnip-configuration|
+4. Miscellaneous               |minisnip-miscellaneous|
 
 ===============================================================================
 OVERVIEW                                                    *minisnip-overview*
@@ -104,3 +105,15 @@ of how it can be used: >
 <
 This will automatically fill the `#define` line with the value entered on the
 `#ifndef` line upon jumping to it.
+
+===============================================================================
+MISCELLANEOUS                                          *minisnip-miscellaneous*
+
+-------------------------------------------------------------------------------
+
+Syntax highlighting for minisnips:
+
+If you would like to have the minisnip delimeters hightlighted for better
+visibility in your minisnip files, add the following to your `.vimrc`: >
+    autocmd BufRead,BufNewFile /path/to/minisnips/* set filetype=minisnip
+<


### PR DESCRIPTION
* added documentation for syntax highlighting

Added a "miscellaneous" section to the doc file that describes how to enable syntax highlight for minisnips.

* removed a copied section

Copied a section to use the formatting and didn't remove it when done. Fixed now.

* corrected spelling and reworded  miscellaneous

Reworded the paragraph in the miscellaneous section and fixed a spelling error.

* removed redundant wording